### PR TITLE
[ENG-9279] Add external id endpoint and update customer endpoint response with external id

### DIFF
--- a/account_api.md
+++ b/account_api.md
@@ -213,3 +213,7 @@ curl -d '{"authentication":{"protocol":"assume_role","assume_role_arn":"arn:123"
 ### Delete Account
 
 `DELETE https://chapi.cloudhealthtech.com/v1/aws_accounts/:id`
+
+### Generate IAM Role External ID
+
+`GET https://chapi.cloudhealthtech.com/v1/aws_accounts/:id/generate_external_id`

--- a/partner_customer_api.md
+++ b/partner_customer_api.md
@@ -49,6 +49,7 @@ Response:
     "margin_percentage": 0.0,
     "created_at": "2016-09-15T18:17:04Z",
     "updated_at": "2016-09-15T18:17:04Z",
+    "generated_external_id": "1a2b3c4d5e6f",
     "partner_billing_configuration": {
         "enabled": true,
         "folder": ""
@@ -124,6 +125,8 @@ The following attributes are supported for customers.
 
 * `updated_at`: When the customer attributes were last modified
 
+* `generated_external_id`: External ID required for accounts with IAM Role Authorization
+
 * `billing_configuration_status`: configuration status (Healthy or not Healthy)
 
 * `billing_configuration_reason`: configuration reason for non-healthy
@@ -152,6 +155,7 @@ Response:
     "margin_percentage": 0.0,
     "created_at": "2016-09-15T13:10:47Z",
     "updated_at": "2016-09-15T16:46:34Z",
+    "generated_external_id": "1a2b3c4d5e6f",
     "partner_billing_configuration": {
         "enabled": true,
         "folder": ""


### PR DESCRIPTION
To reflect these updates to the API:
- Endpoint added under AWS Accounts to retrieve a generated external id.
- Generated External ID added to the response of customers endpoint. 

AWS Best Practices using IAM Role External ID
http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html