### PR TITLE
Example showing use of include parameter in Asset API

### DIFF
--- a/_asset/asset-query-examples.md
+++ b/_asset/asset-query-examples.md
@@ -61,4 +61,15 @@ content_markdown: |-
       &name=AwsVolume
       &fields=in_use,attr_group__33XXSSDDYYYY,account.name
     ```
+
+    #### Include only instance as related object when searching for AWS Volumes
+    ```
+    curl 'https://chapi.cloudhealthtech.com/api/search?
+      &api_key=<your_api_key>
+      &api_version=2
+      &page=1
+      &per_page=5
+      &name=AwsVolume
+      &include=instance
+    ```
 ---

--- a/_asset/query-asset-object.md
+++ b/_asset/query-asset-object.md
@@ -13,7 +13,7 @@ parameters:
     content: Criteria for finding assets of a particular asset object type. Criteria are specified as `query=[field value][operator][value]`. For example, `query=name='MyAccount'+and+is_private=0`
   - name: include
     required: no
-    content: String that specifies the name of a related asset object to include when returning a response.
+    content: String that specifies the name of a related asset object to include when returning a response. You cannot use both the `include` parameter and the `fields` parameter in the same GET query.
   - name: api_version
     required: no
     content: Integer that specifies the API version to use. Possible values are `1` (default) and `2`. Version 1 queries only return assets are are active. Version 2 queries return both active and inactive assets.


### PR DESCRIPTION
Clarified that `include` cannot be used with `fields` in the Asset API.
Added example demonstrating use of `include` to return specified
related objects.