### PR TITLE
Documenting `from` and `to` parameters in Metrics API

### DIFF
--- a/_asset/get-asset-list.md
+++ b/_asset/get-asset-list.md
@@ -12,7 +12,7 @@ content_markdown: |-
 right_code_blocks:
   - code_block: |
       curl 'https://chapi.cloudhealthtech.com/api?
-        api_key=<<your_API_key>'
+        api_key=<your_api_key>'
     title: Request
     language: bash
   - code_block: |-

--- a/_metrics/get-metrics-for-an-asset.md
+++ b/_metrics/get-metrics-for-an-asset.md
@@ -7,10 +7,16 @@ endpoint: https://chapi.cloudhealthtech.com/v1/metrics
 parameters:
   - name: asset
     required: yes
-    content: String that specifies the AWS ARN that identifies the asset. The format is `arn:aws:ec2:<region>:<account-number>:instance/<AWS-instance-ID>`. For example, `arn:aws:ec2:us-east-1:123456789012:instance/i-01a1234b56cdef7g8`.
+    content: String that specifies the AWS ARN that identifies the asset. The format is `arn:aws:ec2:<region>:<owner-id>:instance/<AWS-instance-ID>`. For example, `arn:aws:ec2:us-east-1:123456789012:instance/i-01a1234b56cdef7g8`.
   - name: granularity
     required: no
     content: String that specifies the resolution at which data should be returned. Possible values are `hour` (default), `day`, `week`, and `month`.
+  - name: from
+    required: no
+    content: Date in `YYYY-MM-DD` format that specifies the start date from which you want to see metrics for the asset. You can use this parameter in conjunction with the `to` parameter to specify a custom date range for metrics retrieval.
+  - name: to
+    required: no
+    content: Date in `YYYY-MM-DD` format that specifies the end date up to which you want to see metrics for the asset. You can use this parameter in conjunction with the `from` parameter to specify a custom date range for metrics retrieval.
   - name: time_range
     required: no
     content: String that specifies the time range limit to use when returning data. Possible values are `yesterday` (default), `mtd`, `last_month`, `last_3_months`, `last_6_months`, `last_12_months`, `wtd`, `last_week`, `last_2_weeks`, `last_4_weeks`, `last_52_weeks`, `today`, `yesterday`, `last_2_days`, `last_7_days`, `last_14_days`, and `last_31_days`
@@ -31,14 +37,13 @@ content_markdown: |-
   In addition, rollups are calculated daily. You will not receive `today`'s data at any `granularity` other than `hourly`, which is the default value.
 right_code_blocks:
   - code_block: |-
-      curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/metrics/v1/?api_key=<your api key>"`
+      curl 'https://chapi.cloudhealthtech.com/metrics/v1/?
+        api_key=<your_API_key>
+        &asset=arn:aws:ec2:<region>:<owner-id>:instance/<AWS-instance-ID>'
     title: Request
     language: bash
   - code_block: |-
       {
-        "request" : {
-          "next" : "https://chapi.cloudhealthtech.com/metrics/v1?api_key=<API_KEY>&asset=<AWS_ARN>&page=2",
-        },
         "datasets": [
           "metadata" : {
             "assetType" : "aws:ec2:instance",

--- a/_metrics/metrics-post-data-format.md
+++ b/_metrics/metrics-post-data-format.md
@@ -153,7 +153,7 @@ content_markdown: |-
   Once you build the payload, you can use a cURL command to post it to the `/metrics/v1` endpoint.
 left_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/metrics/v1? api_key=<your_api_key>" -d '{"metrics":{"datasets":[{"metadata":{"assetType":"aws:ec2:instance","granularity":"hour","keys":["assetId","timestamp","memory:usedPercent.avg","memory:usedPercent.max","memory:usedPercent.min"]},"values":[["us-east-1:12345678:i-99999999","2015-06-03T01:00:00+00:00",100.0,200.0,50.0],["us-east-1:12345678:i-88888888","2015-06-03T02:00:00+00:00",25.5,45.2,15.0]]}]}}'
+      curl -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/metrics/v1?api_key=<your_api_key>" -d '{"metrics":{"datasets":[{"metadata":{"assetType":"aws:ec2:instance","granularity":"hour","keys":["assetId","timestamp","memory:usedPercent.avg","memory:usedPercent.max","memory:usedPercent.min"]},"values":[["us-east-1:12345678:i-99999999","2015-06-03T01:00:00+00:00",100.0,200.0,50.0],["us-east-1:12345678:i-88888888","2015-06-03T02:00:00+00:00",25.5,45.2,15.0]]}]}}'
     title: Metrics Post
     language: bash
 ---

--- a/_metrics/post-metrics-for-an-asset.md
+++ b/_metrics/post-metrics-for-an-asset.md
@@ -7,7 +7,7 @@ endpoint: https://chapi.cloudhealthtech.com/v1/metrics
 parameters:
   - name: JSON document
     required: yes
-    content: Payload containing the metrics that you want to post. See [Understand Format of Metrics Payload](#metricsmetrics-post-data-format).
+    content: Payload containing the metrics that you want to post. See [Understand Format of Metrics Payload](#metrics_understand-format-of-metrics-payload).
   - name: dryrun
     required: no
     content: Test a POST operation without triggering a database change. Specified as `true` or `false` (default).
@@ -48,7 +48,8 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/metrics/v1?api_key=<your_api_key>" -d '{"metrics":{"datasets":[{"metadata":{"assetType":"aws:ec2:instance","granularity":"hour","keys":["assetId","timestamp","memory:usedPercent.avg","memory:usedPercent.max","memory:usedPercent.min"]},"values":[["us-east-1:12345678:i-99999999","2015-06-03T01:00:00+00:00",100.0,200.0,50.0],["us-east-1:12345678:i-88888888","2015-06-03T02:00:00+00:00",25.5,45.2,15.0]]}]}}'
+      curl -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/metrics/v1?
+      api_key=<your_api_key>" -d '{"metrics":{"datasets":[{"metadata":{"assetType":"aws:ec2:instance","granularity":"hour","keys":["assetId","timestamp","memory:usedPercent.avg","memory:usedPercent.max","memory:usedPercent.min"]},"values":[["us-east-1:12345678:i-99999999","2015-06-03T01:00:00+00:00",100.0,200.0,50.0],["us-east-1:12345678:i-88888888","2015-06-03T02:00:00+00:00",25.5,45.2,15.0]]}]}}'
     title: Post
     language: bash
   - code_block: |-


### PR DESCRIPTION
Minor bug fixes and documenting `from` and `to` parameters for
specifying custom date ranges in the Metrics API.