### PR TITLE
Added endpoints for setting up GovCloud linkages

### DIFF
--- a/_asset/asset-query-examples.md
+++ b/_asset/asset-query-examples.md
@@ -21,9 +21,8 @@ content_markdown: |-
 
     #### List available fields for Azure Virtual Machines
     ```
-    curl "https://chapi.cloudhealthtech.com/api/search.json?
+    curl "https://chapi.cloudhealthtech.com/api/AzureVm?
       &api_key=<your_api_key>"
-      &name=AzureVm
     ```
 
     #### List available fields for AWS Load Balancer

--- a/_partner/get-single-govcloud-linkage.md
+++ b/_partner/get-single-govcloud-linkage.md
@@ -1,0 +1,29 @@
+---
+title: Details of Single GovCloud Linkage
+position: 14
+description: Get details for a specific GovCloud linkage.
+type: get
+endpoint: https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages/:id
+parameters:
+  - name: client_api_id
+    required: yes
+    content: String that specifies the unique customer API Key that CloudHealth generates. See [How to Get Client API ID](#partner_how-to-get-client-api-id).
+right_code_blocks:
+  - code_block: |-
+      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages/25?
+      api_key=<your_api_key>"
+      &client_api_id=<customer_api_id>
+    title: Request
+    language: bash
+  - code_block: |-
+      {
+          "id": 25,
+          "customer_id": ZZZZ,
+          "govcloud_acct": 5,
+          "commercial_acct": 8,
+          "created_at": "2018-05-16T20:18:58Z",
+          "updated_at": "2018-05-16T20:18:58Z"
+      }
+    title: Response
+    language: bash
+---

--- a/_partner/linkage-post-data-format.md
+++ b/_partner/linkage-post-data-format.md
@@ -1,0 +1,25 @@
+---
+title: Understand Format of GovCloud Linkage Payload
+position: 16
+content_markdown: |-
+  Familiarize yourself with the format of the payload that you can post to define the linkage between a GovCloud Commercial Account and a GovCloud Asset Account.
+
+  **GovCloud Commercial Account:** The proxy account that contains the costs for the account in the Detailed Billing Record.
+
+  **GovCloud Asset Account:** The account that owns the AWS assets.
+
+  Express a linkage between two of these accounts in the following format:
+
+  ```
+  {
+    "govcloud_acct_id": 1,
+    "commercial_acct_id": 2
+  }
+  ```
+
+  In order to get the values of `govcloud_acct_id` and `commercial_acct_id` use these steps:
+  1. Make a GET request as shown in [AWS Accounts in CloudHealth](#account_aws-accounts-in-cloudhealth).
+  2. From the response, which contains all AWS accounts associated with the customer, isolate the GovCloud Commercial Account and the GovCloud Asset Account.
+  3. Copy the value of the `id` field for both accounts.
+  4. Use the `id` of the GovCloud Commercial Account as the value of `govcloud_acct_id` and the `id` of the GovCloud Asset Account as the value of `commercial_acct_id`.
+---

--- a/_partner/list-govcloud-linkages.md
+++ b/_partner/list-govcloud-linkages.md
@@ -1,0 +1,47 @@
+---
+title: List All GovCloud Linkages Owned by Current Customer
+position: 13
+description: Get all GovCloud linkages that are owned by the current customer.
+type: get
+endpoint: https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages
+parameters:
+  - name: client_api_id
+    required: yes
+    content: String that specifies the unique customer API Key that CloudHealth generates. See [How to Get Client API ID](#partner_how-to-get-client-api-id).
+right_code_blocks:
+  - code_block: |-
+      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages?
+      api_key=<your_api_key>"
+      &client_api_id=<customer_api_id>
+    title: Request
+    language: bash
+  - code_block: |-
+      [
+        {
+          "id": 8,
+          "customer_id": XXXX,
+          "govcloud_acct": 1,
+          "commercial_acct": 2,
+          "created_at": "2018-05-16T20:18:58Z",
+          "updated_at": "2018-05-16T20:18:58Z"
+        },
+        {
+          "id": 17,
+          "customer_id": YYYY,
+          "govcloud_acct": 3,
+          "commercial_acct": 6,
+          "created_at": "2018-05-16T20:18:58Z",
+          "updated_at": "2018-05-16T20:18:58Z"
+        },
+        {
+          "id": 25,
+          "customer_id": ZZZZ,
+          "govcloud_acct": 5,
+          "commercial_acct": 8,
+          "created_at": "2018-05-16T20:18:58Z",
+          "updated_at": "2018-05-16T20:18:58Z"
+        }
+      ]
+    title: Response
+    language: bash
+---

--- a/_partner/post-govcloud-account-linkage.md
+++ b/_partner/post-govcloud-account-linkage.md
@@ -1,0 +1,49 @@
+---
+title: Connect GovCloud Commercial Account to GovCloud Asset Account
+position: 12
+description: Link a GovCloud account that receives the Detailed Billing Record with the GovCloud account that owns AWS assets.
+type: post
+endpoint: https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages
+parameters:
+  - name: client_api_id
+    required: yes
+    content: String that specifies the unique customer API Key that CloudHealth generates. See [How to Get Client API ID](#partner_how-to-get-client-api-id)
+  - name: JSON document
+    required: yes
+    content: Payload containing a single relationship between a GovCloud Commercial Account and a GovCloud Asset Account. See [Understand Format of GovCloud Linkage Payload](#partner_understand-format-of-govcloud-linkage-payload).
+content_markdown: |-
+  **GovCloud Commercial Account:** The proxy account that contains the costs for the account in the Detailed Billing Record.
+
+  **GovCloud Asset Account:** The account that owns the AWS assets.
+
+  The CloudHealth Platform validates the relationship between these two accounts as expressed by the JSON payload by using these considerations.
+  * Both accounts are owned by the customer associated with the logged in user.
+  * Neither account is in an existing GovCloud relation
+  * The GovCloud Asset Account specified must have `is_govcloud` set to `true`, indicating that it is associated with a GovCloud region.
+  * The GovCloud Commercial account is the opposite, must not be in the AWS GovCloud Region.
+
+  If any of these validations fails, a list of errors is returned.
+
+right_code_blocks:
+  - code_block: |-
+      curl -H "Content-Type: application/json" -XPOST 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages?
+      api_key=<your_api_key>
+      &client_api_id=<customer_api_id>' -d
+      {
+        "govcloud_acct_id": 1,
+        "commercial_acct_id": 2
+      }
+    title: Request
+    language: bash
+  - code_block: |-
+      {
+        "id": 8,
+        "customer_id": XXXX,
+        "govcloud_acct": 1,
+        "commercial_acct": 2,
+        "created_at": "2018-05-16T20:18:58Z",
+        "updated_at": "2018-05-16T20:18:58Z"
+      }
+    title: Response
+    language: bash
+---

--- a/_partner/update-single-govcloud-linkage.md
+++ b/_partner/update-single-govcloud-linkage.md
@@ -1,0 +1,33 @@
+---
+title: Update Single GovCloud Linkage
+position: 15
+description: Update a specific relationship between a GovCloud Commercial Account and GovCloud Asset Account.
+type: put
+endpoint: https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages/:id
+parameters:
+  - name: client_api_id
+    required: yes
+    content: String that specifies the unique customer API Key that CloudHealth generates. See [How to Get Client API ID](#partner_how-to-get-client-api-id).
+right_code_blocks:
+  - code_block: |-
+      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages/25?
+      api_key=<your_api_key>"
+      &client_api_id=<customer_api_id> -d
+      {
+        "govcloud_acct_id": 17,
+        "commercial_acct_id": 25
+      }
+    title: Request
+    language: bash
+  - code_block: |-
+      {
+          "id": 25,
+          "customer_id": ZZZZ,
+          "govcloud_acct": 17,
+          "commercial_acct": 25,
+          "created_at": "2018-05-16T20:18:58Z",
+          "updated_at": "2018-05-16T20:18:58Z"
+      }
+    title: Response
+    language: bash
+---

--- a/_reporting/get-one-standard-report.md
+++ b/_reporting/get-one-standard-report.md
@@ -18,7 +18,7 @@ parameters:
     required: no
     content: Array that specifies the filters to use for constraining report data.
 content_markdown: |-
-  Retrieving the data for a specific Standard report, such as `/cost/history`, `/cost/current`, or `/usage/instance-hours` involves the following steps.
+  Retrieving the data for a specific Standard report, such as `/cost/history`, `/cost/current`, or `/usage/instance` involves the following steps.
 
   1. Get the endpoints for all types of Standard reports.
 
@@ -51,24 +51,17 @@ content_markdown: |-
 
      This query returns the following response, which has been truncated here for simplification.
 
+     **Note:** Only those reports that have `/olap_reports` in their endpoint are accessible through the API.
+
      ```
      {  
      "links":{
         [...]
-        "usage/emr/cluster-hours":{  
-          "href":"https://chapi.cloudhealthtech.com/olap_reports/usage/emr/cluster-hours"
-        },
         "usage/instance":{  
           "href":"https://chapi.cloudhealthtech.com/olap_reports/usage/instance"
         },
-        "usage/instance-hours":{  
-          "href":"https://chapi.cloudhealthtech.com/olap_reports/usage/instance-hours"
-        },
-        "usage/instance/availability":{  
-          "href":"https://chapi.cloudhealthtech.com/olap_reports/usage/instance/availability"
-        },
-        "usage/instance/bursting":{  
-          "href":"https://chapi.cloudhealthtech.com/olap_reports/usage/instance/bursting"
+        "usage/volume":{  
+          "href":"https://chapi.cloudhealthtech.com/olap_reports/volume"
         },
         [...]
       }

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -449,7 +449,7 @@ hr {
 		word-wrap: break-word;
 	}
 
-	ul {
+	ul, ol {
 		margin: 0px 0px 10px 0px;
 		li {
 			font-weight: 300;


### PR DESCRIPTION
Explained the payload for establishing GovCloud Commercial and GovCloud
Asset account linkages. Fixed two bugs in Asset and Reporting API docs.