### PR TITLE
Remove reference to CHT Query Language

### DIFF
--- a/_documentation/how-to-use-api.md
+++ b/_documentation/how-to-use-api.md
@@ -27,7 +27,7 @@ content_markdown: |-
   * Customer Statement
 
   #### Anatomy of a Request
-  Here's a REST-based query that uses the CloudHealth Query Language.
+  Here's a REST-based query that uses the CloudHealth API.
 
   ```
   curl 'https://chapi.cloudhealthtech.com/olap_reports/cost/history?api_key=XXXXX98900000YYYY&interval=monthly' -H 'Accept: application/json'


### PR DESCRIPTION
Removing incorrect reference to CloudHealth Query Language. It should
be CloudHealth API