### PR TITLE
Fix error format

### DIFF
--- a/_documentation/errors.md
+++ b/_documentation/errors.md
@@ -25,8 +25,7 @@ content_markdown: |-
 left_code_blocks:
   - code_block: |-
       {
-        "error": true,
-        "message": "error message here"
+        "error": "error message here"
       }
     title: Error Response Structure
     language: json


### PR DESCRIPTION
I'm changing this error message for what seems 

For a 403 response I received:
```
{"error":"Unrecognized API key"}
```

For a 401 response I received
```
{"error":"You need to sign in or sign up before continuing"}
```

It looks like at least these errors are in a format different that what the documentation specifies.