### PR TITLE
Add undocumented 20X responses

### DIFF
--- a/_documentation/errors.md
+++ b/_documentation/errors.md
@@ -12,6 +12,7 @@ content_markdown: |-
   | Code | Name | Description |
   | --- | --- | --- |
   | 200 | OK | Success |
+  | 204 | OK | Success |
   | 400 | Bad Request | Header missing |
   | 401 | Unauthorized | Currently logged out |
   | 403 | Forbidden | Bad API Key |

--- a/_documentation/errors.md
+++ b/_documentation/errors.md
@@ -12,6 +12,7 @@ content_markdown: |-
   | Code | Name | Description |
   | --- | --- | --- |
   | 200 | OK | Success |
+  | 201 | OK | Success |
   | 204 | OK | Success |
   | 400 | Bad Request | Header missing |
   | 401 | Unauthorized | Currently logged out |


### PR DESCRIPTION
Got a 204 HTTP response that wasn't documented when calling "Delete AWS Account".

I wonder if there are other methods that return 204s. If none of them return an HTTP body (like Delete AWS Account), it would be nice to annotate that the HTTP response has no body in the docu? Can you guys at CHT confirm if there are other 204s returned by other operations, and if none of them have HTTP bodies?