### PR TITLE
Indicate where arrays are expected

### DIFF
--- a/_account/aws-account-add.md
+++ b/_account/aws-account-add.md
@@ -69,7 +69,7 @@ parameters:
         content: Should CloudHealth collect AWS Config files? Default value is `True`
   - name: tags
     required: no
-    content: JSON field that specifies key-value pairs for tags. When you use this field, The API restricts queries to AWS accounts that are tagged with these key-value pairs.
+    content: JSON array that specifies key-value pairs for tags. When you use this field, The API restricts queries to AWS accounts that are tagged with these key-value pairs.
     sub-fields:
       - name: key
         required: yes

--- a/_partner/customer-account-add.md
+++ b/_partner/customer-account-add.md
@@ -51,7 +51,7 @@ parameters:
         content: String that specifies the prefix of the S3 folder that contains processed customer bills.
   - name: tags
     required: no
-    content: JSON field that specifies key-value pairs for tags to attach to the customer. Each customer can be assigned a maximum of 20 tags.
+    content: JSON array that specifies key-value pairs for tags to attach to the customer. Each customer can be assigned a maximum of 20 tags.
     sub-fields:
       - name: key
         required: yes


### PR DESCRIPTION
There is no indication that these fields are JSON arrays (you have to look at the example data to confirm that they are supposed to be arrays). This is an attempt to document that these fields are arrays