### PR TITLE
Specify cases for required Content-Type: application/json header

### DIFF
--- a/_documentation/how-to-use-api.md
+++ b/_documentation/how-to-use-api.md
@@ -54,6 +54,9 @@ content_markdown: |-
     curl 'https://chapi.cloudhealthtech.com/olap_reports/cost/history?api_key=XXXXX98900000YYYY&interval=monthly' -H 'Accept: application/json'
     ```
   * POST requests send data to the CloudHealth Platform. They include a JSON-formatted message body, which contains the data that should be sent. Here, the message body is specified as a parameter following the `-d` flag.
+
+  * The `Content-Type: application/json` header is required when PUTting or POSTing JSON to the API, else an HTTP 422 Unprocessable Entity is issued
+
     ```
     curl 'https://chapi.cloudhealthtech.com/v1/perspective_schemas?api_key=XXXXX98900000YYYY'
       -H 'content-type: application/json'


### PR DESCRIPTION
For PUT/POST operations where a JSON payload is required, the API expects
a Content-Type of application/json, else it rejects the request as if
no JSON content had been sent. curl seems to set this header automatically,
but other user agents may require it be set explicitly