### PR TITLE
Specify API key as Authorization header

### DIFF
--- a/_account/aws-account-add.md
+++ b/_account/aws-account-add.md
@@ -185,7 +185,7 @@ right_code_blocks:
             "value": "Production"
           }]
         }'
-        -H 'Content-Type: application/json' --request POST 'https://chapi.cloudhealthtech.com/v1/aws_accounts?api_key=<your_api_key>'
+        -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' --request POST 'https://chapi.cloudhealthtech.com/v1/aws_accounts'
     title: Sample Request
     language: bash
 ---

--- a/_account/aws-account-delete.md
+++ b/_account/aws-account-delete.md
@@ -7,7 +7,7 @@ endpoint: https://chapi.cloudhealthtech.com/v1/aws_accounts/:id
 description: Delete an AWS Account from the CloudHealth Platform
 right_code_blocks:
   - code_block: |-
-      curl --request DELETE -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts/:id?api_key=<your_api_key>"
+      curl --request DELETE -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' 'https://chapi.cloudhealthtech.com/v1/aws_accounts/:id'
     title: Sample Request
     language: bash
 ---

--- a/_account/aws-account-read-multiple.md
+++ b/_account/aws-account-read-multiple.md
@@ -13,15 +13,15 @@ parameters:
     content: Specify how many results should be displayed per page. Default value is 30.
 right_code_blocks:
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts?api_key=<your_api_key>"
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts"
     title: All results
     language: bash
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts?api_key=<your_api_key>&page=2"
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts?page=2"
     title: Specific page
     language: bash
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts?api_key=<your_api_key>&page=3&per_page=100"
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts?page=3&per_page=100"
     title: Results per page
     language: bash
 ---

--- a/_account/aws-account-read-single.md
+++ b/_account/aws-account-read-single.md
@@ -7,7 +7,7 @@ endpoint: https://chapi.cloudhealthtech.com/v1/aws_accounts/:id
 
 right_code_blocks:
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts/<account_ID>?api_key=<your_api_key>"
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts/<account_ID>"
     title: Sample Request
     language: bash
 ---

--- a/_account/aws-account-update.md
+++ b/_account/aws-account-update.md
@@ -98,7 +98,7 @@ right_code_blocks:
     title: Sample Request Body
     language: json
   - code_block: |-
-      curl -d '{"authentication":{"protocol":"assume_role","assume_role_arn":"arn:123","assume_role_external_id":"61a1XXXXXXXXXXXXXXXXXXXXX5d8c6"},"name":"Tools 123"}' -H 'Content-Type: application/json' --request PUT 'https://chapi.cloudhealthtech.com/v1/aws_accounts/<account_id>?api_key=<your_api_key>'
+      curl -d '{"authentication":{"protocol":"assume_role","assume_role_arn":"arn:123","assume_role_external_id":"61a1XXXXXXXXXXXXXXXXXXXXX5d8c6"},"name":"Tools 123"}' -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' --request PUT 'https://chapi.cloudhealthtech.com/v1/aws_accounts/<account_id>'
     title: Sample Request
     language: bash
 ---

--- a/_account/external-id-get.md
+++ b/_account/external-id-get.md
@@ -17,7 +17,7 @@ content_markdown: |-
   You can also get your API key through an endpoint.
 right_code_blocks:
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts/:id/generate_external_id?api_key=<your_api_key>"
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts/:id/generate_external_id"
     title: Sample Request
     language: bash
 ---

--- a/_asset/asset-query-examples.md
+++ b/_asset/asset-query-examples.md
@@ -9,40 +9,38 @@ parameters:
 content_markdown: |-
     #### List API names for all asset types
     ```
-    curl "https://chapi.cloudhealthtech.com/api?
-      &api_key=<your_api_key>"
+    curl -H 'Authorization: Bearer <your_api_key>'
+      "https://chapi.cloudhealthtech.com/api"
     ```
 
     #### List available fields for AWS RDS Instances
     ```
-    curl "https://chapi.cloudhealthtech.com/api/AwsRdsInstance?
-      &api_key=<your_api_key>"
+    curl -H 'Authorization: Bearer <your_api_key>'
+      "https://chapi.cloudhealthtech.com/api/AwsRdsInstance"
     ```
 
     #### List available fields for Azure Virtual Machines
     ```
-    curl "https://chapi.cloudhealthtech.com/api/AzureVm?
-      &api_key=<your_api_key>"
+    curl -H 'Authorization: Bearer <your_api_key>'
+      "https://chapi.cloudhealthtech.com/api/AzureVm"
     ```
 
     #### List available fields for AWS Load Balancer
     ```
-    curl "https://chapi.cloudhealthtech.com/api/AwsLoadBalancer?
-      &api_key=<your_api_key>"
+    curl -H 'Authorization: Bearer <your_api_key>'
+      "https://chapi.cloudhealthtech.com/api/AwsLoadBalancer"
     ```
 
     #### Filter AWS Load Balancers by name
     ```
-    curl "https://chapi.cloudhealthtech.com/api/search?
-      &api_key=<your_api_key>
+    curl -H 'Authorization: Bearer <your_api_key>' "https://chapi.cloudhealthtech.com/api/search?
       &name=AwsLoadBalancer
       &query=name='a45075XXXXXXYYYYYYZZZZZ96f99'"
     ```
 
     #### Filter RDS Instances by instance ID and only display the instance IDs in the response
     ```
-    curl "https://chapi.cloudhealthtech.com/api/search?
-      &api_key=<your_api_key>
+    curl -H 'Authorization: Bearer <your_api_key>' "https://chapi.cloudhealthtech.com/api/search?
       &name=AwsRdsInstance
       &api_version=2
       &fields=instance_id
@@ -51,8 +49,7 @@ content_markdown: |-
 
     #### List active AWS Volumes and only display their Perspective Groups and Accounts in the response
     ```
-    curl https://chapi.cloudhealthtech.com/api/search?
-      &api_key=<your_api_key>
+    curl -H 'Authorization: Bearer <your_api_key>' https://chapi.cloudhealthtech.com/api/search?
       &api_version=2
       &page=1
       &per_page=5
@@ -63,8 +60,7 @@ content_markdown: |-
 
     #### Include only instance as related object when searching for AWS Volumes
     ```
-    curl 'https://chapi.cloudhealthtech.com/api/search?
-      &api_key=<your_api_key>
+    curl -H 'Authorization: Bearer <your_api_key>' 'https://chapi.cloudhealthtech.com/api/search?
       &api_version=2
       &page=1
       &per_page=5

--- a/_asset/get-asset-list.md
+++ b/_asset/get-asset-list.md
@@ -11,8 +11,7 @@ content_markdown: |-
   The response to this query contains a list of JSON objects that represent all the AWS, Azure, Data Center, and Google Cloud assets that CloudHealth has discovered in your environment.
 right_code_blocks:
   - code_block: |
-      curl 'https://chapi.cloudhealthtech.com/api?
-        api_key=<your_api_key>'
+      curl -H 'Authorization: Bearer <your_api_key>' 'https://chapi.cloudhealthtech.com/api'
     title: Request
     language: bash
   - code_block: |-

--- a/_asset/get-specific-asset.md
+++ b/_asset/get-specific-asset.md
@@ -15,8 +15,7 @@ content_markdown: |-
   The `relations` array contains related assets. In the case of an AWS Instance, the `relations` array lists objects such as `AwsAccount`, `AWSInstanceType`, `AwsAvailabilityZone`, and `ChefNode` objects.
 right_code_blocks:
   - code_block: |
-      curl 'https://chapi.cloudhealthtech.com/api/AwsInstance?
-        api_key=<your_API_key>'
+      curl -H 'Authorization: Bearer <your_api_key>' 'https://chapi.cloudhealthtech.com/api/AwsInstance'
     title: Request
     language: bash
   - code_block: |-

--- a/_asset/query-asset-object.md
+++ b/_asset/query-asset-object.md
@@ -34,8 +34,7 @@ content_markdown: |-
   See [Asset Query Examples](#assetasset-query-examples).
 right_code_blocks:
   - code_block: |
-      curl 'https://chapi.cloudhealthtech.com/api/search?
-        &api_key=<your_API_key>
+      curl -H 'Authorization: Bearer <your_api_key>' 'https://chapi.cloudhealthtech.com/api/search?
         &api_version=2
         &page=1
         &per_page=5

--- a/_assignment/aws-account-assignment-create-v2.md
+++ b/_assignment/aws-account-assignment-create-v2.md
@@ -104,7 +104,10 @@ right_code_blocks:
     title: Response Body
     language: bash
   - code_block: |-
-      curl --request POST -H 'Content-Type: application/json' -d\
+      curl --request POST
+        -H 'Authorization: Bearer <your_api_key>'
+        -H 'Content-Type: application/json'
+        -d\
         '{
           "aws_account_assignments": [
             {
@@ -133,7 +136,7 @@ right_code_blocks:
             }
           ]
         }'\
-        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments?api_key=<your_api_key>'
+        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments'
     title: Sample Request
     language: bash
 ---

--- a/_assignment/aws-account-assignment-create.md
+++ b/_assignment/aws-account-assignment-create.md
@@ -49,13 +49,15 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request POST -H 'Content-Type: application/json' -d
+      curl --request POST
+        -H 'Authorization: Bearer <your_api_key>'
+        -H 'Content-Type: application/json' -d
         '{
           "owner_id": "000000000001",
           "customer_id": 1,
           "payer_account_owner_id": "000000000001"
         }'
-        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments?api_key=<your_api_key>'
+        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments'
     title: Sample Request
     language: bash
 ---

--- a/_assignment/aws-account-assignment-delete-v2.md
+++ b/_assignment/aws-account-assignment-delete-v2.md
@@ -12,9 +12,11 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl --request DELETE \
-        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments/<id>?api_key=<your_api_key>' \
+      curl --request
+        -H 'Authorization: Bearer <your_api_key>'
         -H 'Content-Type: application/json'
+        DELETE \
+        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments/<id>' \
     title: Sample Request
     language: bash
 ---

--- a/_assignment/aws-account-assignment-delete.md
+++ b/_assignment/aws-account-assignment-delete.md
@@ -24,8 +24,10 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl --request DELETE -H 'Content-Type: application/json'
-        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments/<id>?api_key=<your_api_key>'
+      curl --request
+        -H 'Authorization: Bearer <your_api_key>'
+        DELETE -H 'Content-Type: application/json'
+        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_assignment/aws-account-assignment-read-single-v2.md
+++ b/_assignment/aws-account-assignment-read-single-v2.md
@@ -12,12 +12,13 @@ content_markdown: |-
   * `target_client_api_id`: the client API ID of the customer
   * `payer_account_owner_id`: The AWS ID of the account whose bills receive the billing line items for the assigned account
   * `billing_block_type`: The type of billing block
-  * `billing_block_name`: The name of the billing block 
+  * `billing_block_name`: The name of the billing block
 
 right_code_blocks:
   - code_block: |-
       curl --request GET \
-        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments/<id>?api_key=<your_api_key>' \
+        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments/<id>' \
+        -H 'Authorization: Bearer <your_api_key>'
         -H 'Content-Type: application/json'
     title: Sample Request
     language: bash

--- a/_assignment/aws-account-assignment-read-single.md
+++ b/_assignment/aws-account-assignment-read-single.md
@@ -20,8 +20,8 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments/<id>?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_assignment/aws-account-assignment-read-v2.md
+++ b/_assignment/aws-account-assignment-read-v2.md
@@ -23,8 +23,9 @@ content_markdown: |-
 right_code_blocks:
   - code_block: |-
       curl --request GET \
-        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments/?api_key=<your_api_key>' \
+        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments/' \
         -H 'Content-Type: application/json'
+        -H 'Authorization: Bearer <your_api_key>'
     title: Sample Request
     language: bash
 ---

--- a/_assignment/aws-account-assignment-read.md
+++ b/_assignment/aws-account-assignment-read.md
@@ -21,8 +21,8 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments/?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments/'
     title: Sample Request
     language: bash
 ---

--- a/_assignment/aws-account-assignment-update-v2.md
+++ b/_assignment/aws-account-assignment-update-v2.md
@@ -51,12 +51,12 @@ right_code_blocks:
     title: Response Body
     language: bash
   - code_block: |-
-      curl --request PUT -H 'Content-Type: application/json' -d\
+      curl --request PUT -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d\
         '{
           "billing_block_name": "block name2",
           "payer_account_owner_id":"000000000003"
         }'\
-        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments/<target_client_api_id>?api_key=<your_api_key>'
+        'https://chapi.cloudhealthtech.com/v2/aws_account_assignments/<target_client_api_id>'
     title: Sample Request
     language: bash
 ---

--- a/_assignment/aws-account-assignment-update.md
+++ b/_assignment/aws-account-assignment-update.md
@@ -33,13 +33,13 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl --request PUT -H 'Content-Type: application/json' -d
+      curl --request PUT -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "owner_id": "000000000001",
           "customer_id": 1,
           "payer_account_owner_id": "000000000001"
         }'
-        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments/<id>?api_key=<your_api_key>'
+        'https://chapi.cloudhealthtech.com/v1/aws_account_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_documentation/how-to-use-api.md
+++ b/_documentation/how-to-use-api.md
@@ -27,35 +27,39 @@ content_markdown: |-
   * Customer Statement
 
   #### Anatomy of a Request
-  Here's a REST-based query that uses the CloudHealth API.
+  Here's a REST-based request that uses the CloudHealth API.
 
   ```
-  curl 'https://chapi.cloudhealthtech.com/olap_reports/cost/history?api_key=XXXXX98900000YYYY&interval=monthly' -H 'Accept: application/json'
+  curl -H 'Authorization: Bearer XXXXX98900000YYYY' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/cost/history?interval=monthly'
   ```
 
   Let's break down this request.
   * `cURL` is a command-line REST client (https://curl.haxx.se).
+  * The `-H` flags represent the headers that you need to pass with each request. There are two headers that each request must contain:
+     * `-H 'Authorization: Bearer XXXXX98900000YYYY'` is the authorization header. It attaches your unique API key to the request. Here, `XXXXX98900000YYYY` is your API Key. See [How CloudHealth Validates API Requests](#how-cloudhealth-validates-api-requests).
+     * `- H 'Accept: application/json'` is the communication header. You can also specify this header as `-H 'Content-Type:application/json'`.
+     * The optional header `Accept-Encoding:gzip` compresses the communication with GZIP compression.
   * `https://chapi.cloudhealthtech.com/olap_reports/cost/history` is the REST endpoint. In this example, the endpoint returns data for the **Standard Cost History Report**.
-  * `api_key=XXXXX98900000YYYY` attaches your unique API key with the request. See [How CloudHealth Validates API Requests](#how-cloudhealth-validates-api-requests).
+  * If you prefer to pass your API key as a query parameter, instead of using an authorization header, use `api_key=XXXXX98900000YYYY` to attach your unique API key with the request. Here, `XXXXX98900000YYYY` is your API Key.
   * `interval=monthly` is a query parameter that you append to the REST endpoint. Query parameters allow you to constrain the data returned from a request. You can attach multiple query parameter as long as each parameter is separated from the next by the `&` symbol.
-
   * A URI string is made up of the REST endpoint and all the query parameters attached to it. In this example, this is the URI string.
     ```
-    https://chapi.cloudhealthtech.com/olap_reports/cost/history?api_key=XXXXX98900000YYYY&interval=monthly
+    https://chapi.cloudhealthtech.com/olap_reports/cost/history?interval=monthly
     ```
     The maximum permissible length of a URI string is **4000** characters.
     {:.warning}
 
-  * `-H accept: application/json` is the communication header. You can also specify this header as `-H Content-Type:application/json`. All REST API calls must include proper communication headers. The other header you can pass with the CloudHealth API is `Accept-Encoding:gzip`, which compresses the communication with GZIP compression.
-
   #### Types of Requests
   * GET requests retrieve data from the CloudHealth Platform.
     ```
-    curl 'https://chapi.cloudhealthtech.com/olap_reports/cost/history?api_key=XXXXX98900000YYYY&interval=monthly' -H 'Accept: application/json'
+    curl 'https://chapi.cloudhealthtech.com/olap_reports/cost/history?interval=monthly'
+      -H 'Authorization: Bearer XXXXX98900000YYYY'
+      -H 'Accept: application/json'
     ```
   * POST requests send data to the CloudHealth Platform. They include a JSON-formatted message body, which contains the data that should be sent. Here, the message body is specified as a parameter following the `-d` flag.
     ```
-    curl 'https://chapi.cloudhealthtech.com/v1/perspective_schemas?api_key=XXXXX98900000YYYY'
+    curl 'https://chapi.cloudhealthtech.com/v1/perspective_schemas'
+      -H 'Authorization: Bearer XXXXX98900000YYYY'
       -H 'content-type: application/json'
       -d '{
         "schema":{
@@ -73,7 +77,7 @@ right_code_blocks:
   - code_block:
       This area displays code examples that you can copy and paste into a terminal. Before running these examples, make sure you replace placeholder values enclosed within angle brackets <> with actual values.
 
-      For example, all API queries must include your unique API Key. The value of this key is indicated as <your_API_key> in these code examples. Replace this placeholder value with your actual API Key.
+      For example, all API queries must include your unique API Key in the authorization header. The value of this key is indicated as <your_api_key> in these code examples. Replace this placeholder value with your actual API Key.
     title: Code Example Pane
     language: none
 ---

--- a/_metrics/get-metrics-for-an-asset.md
+++ b/_metrics/get-metrics-for-an-asset.md
@@ -38,8 +38,8 @@ content_markdown: |-
 right_code_blocks:
   - code_block: |-
       curl 'https://chapi.cloudhealthtech.com/metrics/v1/?
-        api_key=<your_API_key>
         &asset=arn:aws:ec2:<region>:<owner-id>:instance/<AWS-instance-ID>'
+        -H 'Authorization: Bearer <your_api_key>'
     title: Request
     language: bash
   - code_block: |-

--- a/_metrics/metrics-post-data-format.md
+++ b/_metrics/metrics-post-data-format.md
@@ -154,7 +154,7 @@ content_markdown: |-
   Once you build the payload, you can use a cURL command to post it to the `/metrics/v1` endpoint.
 left_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/metrics/v1?api_key=<your_api_key>" -d '{"metrics":{"datasets":[{"metadata":{"assetType":"aws:ec2:instance","granularity":"hour","keys":["assetId","timestamp","memory:usedPercent.avg","memory:usedPercent.max","memory:usedPercent.min"]},"values":[["us-east-1:12345678:i-99999999","2015-06-03T01:00:00+00:00",100.0,200.0,50.0],["us-east-1:12345678:i-88888888","2015-06-03T02:00:00+00:00",25.5,45.2,15.0]]}]}}'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -XPOST "https://chapi.cloudhealthtech.com/metrics/v1" -d '{"metrics":{"datasets":[{"metadata":{"assetType":"aws:ec2:instance","granularity":"hour","keys":["assetId","timestamp","memory:usedPercent.avg","memory:usedPercent.max","memory:usedPercent.min"]},"values":[["us-east-1:12345678:i-99999999","2015-06-03T01:00:00+00:00",100.0,200.0,50.0],["us-east-1:12345678:i-88888888","2015-06-03T02:00:00+00:00",25.5,45.2,15.0]]}]}}'
     title: Metrics Post
     language: bash
 ---

--- a/_metrics/post-metrics-for-an-asset.md
+++ b/_metrics/post-metrics-for-an-asset.md
@@ -48,8 +48,7 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/metrics/v1?
-      api_key=<your_api_key>" -d '{"metrics":{"datasets":[{"metadata":{"assetType":"aws:ec2:instance","granularity":"hour","keys":["assetId","timestamp","memory:usedPercent.avg","memory:usedPercent.max","memory:usedPercent.min"]},"values":[["us-east-1:12345678:i-99999999","2015-06-03T01:00:00+00:00",100.0,200.0,50.0],["us-east-1:12345678:i-88888888","2015-06-03T02:00:00+00:00",25.5,45.2,15.0]]}]}}'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -XPOST "https://chapi.cloudhealthtech.com/metrics/v1" -d '{"metrics":{"datasets":[{"metadata":{"assetType":"aws:ec2:instance","granularity":"hour","keys":["assetId","timestamp","memory:usedPercent.avg","memory:usedPercent.max","memory:usedPercent.min"]},"values":[["us-east-1:12345678:i-99999999","2015-06-03T01:00:00+00:00",100.0,200.0,50.0],["us-east-1:12345678:i-88888888","2015-06-03T02:00:00+00:00",25.5,45.2,15.0]]}]}}'
     title: Post
     language: bash
   - code_block: |-

--- a/_partner/cust-statement-read-multiple.md
+++ b/_partner/cust-statement-read-multiple.md
@@ -6,7 +6,7 @@ type: get
 endpoint: https://chapi.cloudhealthtech.com/v1/customer_statements
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/v1/customer_statements?api_key=<your_api_key>'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' 'https://chapi.cloudhealthtech.com/v1/customer_statements'
     title: Request
     language: bash
   - code_block: |-

--- a/_partner/cust-statement-read-single.md
+++ b/_partner/cust-statement-read-single.md
@@ -10,7 +10,7 @@ parameters:
     content: String that specifies the unique customer API Key that CloudHealth generates. See [How to Get Client API ID](#partner_how-to-get-client-api-id)
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/v1/customer_statements?api_key=<your_api_key>&client_api_id=<client_api_id>'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' 'https://chapi.cloudhealthtech.com/v1/customer_statements?client_api_id=<client_api_id>'
     title: Request
     language: bash
   - code_block: |-

--- a/_partner/customer-account-add.md
+++ b/_partner/customer-account-add.md
@@ -123,7 +123,7 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request POST -H 'Content-Type: application/json' -d
+      curl --request POST -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "name": "Acme Corp",
           "classification": "managed_without_access",
@@ -141,7 +141,7 @@ right_code_blocks:
             "country": "US"
             }
           }'
-          'https://chapi.cloudhealthtech.com/v1/customers?api_key=<your_api_key>'
+          'https://chapi.cloudhealthtech.com/v1/customers'
     title: Sample Request
     language: bash
 ---

--- a/_partner/customer-account-delete.md
+++ b/_partner/customer-account-delete.md
@@ -6,7 +6,8 @@ type: delete
 endpoint: https://chapi.cloudhealthtech.com/v1/customers/:customer_id
 right_code_blocks:
   - code_block: |-
-      curl -X "DELETE" 'https://chapi.cloudhealthtech.com/v1/customers/<customer_id>?api_key=<your_api_key>'
+      curl -X "DELETE" 'https://chapi.cloudhealthtech.com/v1/customers/<customer_id>'
+        -H 'Authorization: Bearer <your_api_key>'
     title: Sample Request
     language: bash
 ---

--- a/_partner/customer-account-modify.md
+++ b/_partner/customer-account-modify.md
@@ -43,12 +43,12 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request PUT -H 'Content-Type: application/json' -d
+      curl --request PUT -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
       '{
         "name": "Acme Corporation",
         "classification": "managed_with_access"
       }'
-      'https://chapi.cloudhealthtech.com/v1/customers/<customer_id>?api_key=<your_api_key>'
+      'https://chapi.cloudhealthtech.com/v1/customers/<customer_id>'
     title: Sample Request
     language: bash
 ---

--- a/_partner/get-all-customers.md
+++ b/_partner/get-all-customers.md
@@ -6,7 +6,7 @@ type: get
 endpoint: https://chapi.cloudhealthtech.com/v1/customers
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/v1/customers?api_key=<your_api_key>'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' 'https://chapi.cloudhealthtech.com/v1/customers'
     title: Sample Request
     language: bash
 ---

--- a/_partner/get-customer-assets.md
+++ b/_partner/get-customer-assets.md
@@ -13,8 +13,9 @@ parameters:
     content: String that specifies the unique display name of the customer's AWS account.
 right_code_blocks:
   - code_block: |-
-      curl https://chapi.cloudhealthtech.com/api/search.json?api_version=2&api_key=<your_api_key>&client_api_id=<customer_api_id>
-        &name=AwsAccount
+      curl 'https://chapi.cloudhealthtech.com/api/search.json?api_version=2&client_api_id=<customer_api_id>
+        &name=AwsAccount'
+        -H 'Authorization: Bearer <your_api_key>'
     title: Request
     language: bash
 ---

--- a/_partner/get-customer-reports.md
+++ b/_partner/get-customer-reports.md
@@ -12,7 +12,7 @@ content_markdown: |-
   Refer to [Data for Standard Report](#reporting_data-for-standard-report) for more information on retrieving data from a standard report.
 right_code_blocks:
   - code_block: |-
-      curl -H "Accept: application/json" 'https://chapi.cloudhealthtech.com/olap_reports/cost/history?api_key=<your_api_key>&client_api_id=<customer_api_id>'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/cost/history?client_api_id=<customer_api_id>'
     title: Bash Request
     language: bash
   - code_block: |-

--- a/_partner/get-single-customer.md
+++ b/_partner/get-single-customer.md
@@ -6,7 +6,7 @@ type: get
 endpoint: https://chapi.cloudhealthtech.com/v1/customers/:customer_id
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/v1/customers/<customer_id>?api_key=<your_api_key>'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' 'https://chapi.cloudhealthtech.com/v1/customers/<customer_id>'
     title: Sample Request
     language: bash
 ---

--- a/_partner/get-single-govcloud-linkage.md
+++ b/_partner/get-single-govcloud-linkage.md
@@ -10,9 +10,8 @@ parameters:
     content: String that specifies the unique customer API Key that CloudHealth generates. See [How to Get Client API ID](#partner_how-to-get-client-api-id).
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages/25?
-      api_key=<your_api_key>"
-      &client_api_id=<customer_api_id>
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages/25?
+      client_api_id=<customer_api_id>
     title: Request
     language: bash
   - code_block: |-

--- a/_partner/list-govcloud-linkages.md
+++ b/_partner/list-govcloud-linkages.md
@@ -10,9 +10,8 @@ parameters:
     content: String that specifies the unique customer API Key that CloudHealth generates. See [How to Get Client API ID](#partner_how-to-get-client-api-id).
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages?
-      api_key=<your_api_key>
-      &client_api_id=<customer_api_id>'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages?
+      client_api_id=<customer_api_id>'
     title: Request
     language: bash
   - code_block: |-

--- a/_partner/post-govcloud-account-linkage.md
+++ b/_partner/post-govcloud-account-linkage.md
@@ -26,9 +26,8 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" -XPOST 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages?
-      api_key=<your_api_key>
-      &client_api_id=<customer_api_id>' -d
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -XPOST 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages?
+      client_api_id=<customer_api_id>' -d
       {
         "govcloud_acct_id": 1,
         "commercial_acct_id": 2

--- a/_partner/update-single-govcloud-linkage.md
+++ b/_partner/update-single-govcloud-linkage.md
@@ -10,9 +10,8 @@ parameters:
     content: String that specifies the unique customer API Key that CloudHealth generates. See [How to Get Client API ID](#partner_how-to-get-client-api-id).
 right_code_blocks:
   - code_block: |-
-      curl -H "Content-Type: application/json" 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages/25?
-      api_key=<your_api_key>
-      &client_api_id=<customer_api_id>' -d
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' 'https://chapi.cloudhealthtech.com/api/v1/govcloud_linkages/25?
+      client_api_id=<customer_api_id>' -d
       '{
         "govcloud_acct_id": 17,
         "commercial_acct_id": 25

--- a/_perspectives/create-perspective-schema.md
+++ b/_perspectives/create-perspective-schema.md
@@ -17,13 +17,13 @@ content_markdown: |-
 
   For example, this POST call creates a Perspective:
   ```
-  curl -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/v1/perspective_schemas?api_key=<api_key>" -d '{"schema":{"name":"Test 1000002","rules":[{"type":"filter","asset":"AwsInstance","to":"new group 1","condition":{"clauses":[{"field":["Active?"],"op":"=","val":"true"}]}},{"type":"filter","asset":"AwsInstance","to":"new group 1","condition":{"clauses":[{"field":["First Discovered"],"op":">","val":"2016-01-04T23:19:34+00:00"}]}}],"constants":[],"merges":[]}'
+  curl -H 'Content-Type: application/json' -XPOST "https://chapi.cloudhealthtech.com/v1/perspective_schemas?api_key=<api_key>" -d '{"schema":{"name":"Test 1000002","rules":[{"type":"filter","asset":"AwsInstance","to":"new group 1","condition":{"clauses":[{"field":["Active?"],"op":"=","val":"true"}]}},{"type":"filter","asset":"AwsInstance","to":"new group 1","condition":{"clauses":[{"field":["First Discovered"],"op":">","val":"2016-01-04T23:19:34+00:00"}]}}],"constants":[],"merges":[]}'
   ```
 
   When you make a subsequent GET call to retrieve this schema, a new group (Group-1) is created and displayed in the response. All references to `new group 1` in the schema are converted into references to the newly created group.
 right_code_blocks:
   - code_block: |-
-      curl -s -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/v1/perspective_schemas/?api_key=<api_key>" -d '{"schema": {"name": "Environment","include_in_reports": "true",
+      curl -s -H 'Content-Type: application/json' -XPOST "https://chapi.cloudhealthtech.com/v1/perspective_schemas/?api_key=<api_key>" -d '{"schema": {"name": "Environment","include_in_reports": "true",
       "rules": [{"type": "categorize","asset": "AwsAsset","tag_field": ["cht_env"],"ref_id": "5841XXXXXXX853","name": "AWS Assets"}],
       "merges": [{"type": "Group","to": "584XXXXX39263","from": ["584YYYYYY9283"]}],
       "constants": [{"type": "Dynamic Group Block","list": [{"ref_id": "ABCDEFG522853","name": "AWS Assets"}],

--- a/_perspectives/get-perspective-version.md
+++ b/_perspectives/get-perspective-version.md
@@ -5,10 +5,9 @@ description: Include the version of a Perspective in the response.
 position: 8
 right_code_blocks:
   - code_block: |-
-      curl -s -H "Accept: application/json"
+      curl -s -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json'
         "https://chapi.cloudhealthtech.com/v1/perspective_schemas/<perspective_id>
-        ?api_key=<your_api_key>
-        &include_version=true"
+        ?&include_version=true"
     title: Request
     language: bash
   - code_block: |-

--- a/_perspectives/update-perspective-schema.md
+++ b/_perspectives/update-perspective-schema.md
@@ -23,13 +23,13 @@ content_markdown: |-
   #### How to Avoid Conflicts during Concurrent Updates
   Use the `check_version` parameter to ensure that a concurrent update is not overwritten.
   ```
-  curl -s -H "Content-Type: application/json" -XPUT "https://chapi.cloudhealthtech.com/v1/perspective_schemas/<perspective_id>?api_key=<api_key>&check_version=3"
+  curl -s -H 'Content-Type: application/json' -XPUT "https://chapi.cloudhealthtech.com/v1/perspective_schemas/<perspective_id>?api_key=<api_key>&check_version=3"
   ```
 
   If the Perspective was updated, and therefore version-incremented, since the last GET operation, the update request returns a `400` error.
 right_code_blocks:
   - code_block: |-
-      curl -s -H "Content-Type: application/json" -XPUT "https://chapi.cloudhealthtech.com/v1/perspective_schemas/<perspective_id>
+      curl -s -H 'Content-Type: application/json' -XPUT "https://chapi.cloudhealthtech.com/v1/perspective_schemas/<perspective_id>
         ?api_key=<api_key>" -d '{"schema":<schema JSON>}'
     title: Update
     language: bash

--- a/_price-book/price-book-add.md
+++ b/_price-book/price-book-add.md
@@ -31,12 +31,12 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request POST -H 'Content-Type: application/json' -d
+      curl --request POST -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "book_name": "Gold tier",
           "specification": <XML>
         }'
-        'https://chapi.cloudhealthtech.com/v1/price_books?api_key=<your_api_key>'
+        'https://chapi.cloudhealthtech.com/v1/price_books'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-assign-account.md
+++ b/_price-book/price-book-assign-account.md
@@ -66,12 +66,12 @@ right_code_blocks:
     title: Response Body for All Accounts
     language: json
   - code_block: |-
-      curl --request POST -H 'Content-Type: application/json' -d
+      curl --request POST -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "price_book_assignment_id": XXXX,
           "billing_account_owner_id": "ALL"
         }'
-      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments?api_key=<your_api_key>'
+      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-assign-customer.md
+++ b/_price-book/price-book-assign-customer.md
@@ -31,12 +31,12 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request POST -H 'Content-Type: application/json' -d
+      curl --request POST -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "price_book_id": XXXX,
           "target_client_api_id": <client_api_id>
         }'
-        'https://chapi.cloudhealthtech.com/v1/price_book_assignments?api_key=<your_api_key>'
+        'https://chapi.cloudhealthtech.com/v1/price_book_assignments'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-delete-account.md
+++ b/_price-book/price-book-delete-account.md
@@ -6,8 +6,8 @@ type: delete
 endpoint: https://chapi.cloudhealthtech.com/v1/price_book_account_assignments/:id
 right_code_blocks:
   - code_block: |-
-      curl --request DELETE -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments/<id>?api_key=<your_api_key>'
+      curl --request DELETE -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-delete-customer.md
+++ b/_price-book/price-book-delete-customer.md
@@ -6,8 +6,8 @@ type: delete
 endpoint: https://chapi.cloudhealthtech.com/v1/price_book_assignments/:id
 right_code_blocks:
   - code_block: |-
-      curl --request DELETE -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_book_assignments/<id>?api_key=<your_api_key>'
+      curl --request DELETE -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_book_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-delete.md
+++ b/_price-book/price-book-delete.md
@@ -6,8 +6,8 @@ type: delete
 endpoint: https://chapi.cloudhealthtech.com/v1/price_books/:price book id
 right_code_blocks:
   - code_block: |-
-      curl --request DELETE -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_books/<price book id>?api_key=<your_api_key>'
+      curl --request DELETE -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_books/<price book id>'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-get-account.md
+++ b/_price-book/price-book-get-account.md
@@ -15,8 +15,8 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments/<id>?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-get-all-accounts.md
+++ b/_price-book/price-book-get-all-accounts.md
@@ -25,8 +25,8 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-get-all-customers.md
+++ b/_price-book/price-book-get-all-customers.md
@@ -16,8 +16,8 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_book_assignments?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_book_assignments'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-get-all.md
+++ b/_price-book/price-book-get-all.md
@@ -23,8 +23,8 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_books/?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_books/'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-get-customer.md
+++ b/_price-book/price-book-get-customer.md
@@ -16,8 +16,8 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_book_assignments/<id>?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_book_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-get-detail-xml.md
+++ b/_price-book/price-book-get-detail-xml.md
@@ -12,8 +12,8 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_books/<id>/specification?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_books/<id>/specification'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-get-detail.md
+++ b/_price-book/price-book-get-detail.md
@@ -16,8 +16,8 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json'
-      'https://chapi.cloudhealthtech.com/v1/price_books/<id>?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json'
+      'https://chapi.cloudhealthtech.com/v1/price_books/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-modify-account.md
+++ b/_price-book/price-book-modify-account.md
@@ -21,11 +21,11 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request PUT -H 'Content-Type: application/json' -d
+      curl --request PUT -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "billing_account_owner_id": <string>
         }'
-      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments/<id>?api_key=<your_api_key>'
+      'https://chapi.cloudhealthtech.com/v1/price_book_account_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-modify-customer.md
+++ b/_price-book/price-book-modify-customer.md
@@ -22,11 +22,11 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request PUT -H 'Content-Type: application/json' -d
+      curl --request PUT -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "price_book_id": XXXX
         }'
-      'https://chapi.cloudhealthtech.com/v1/price_book_assignments/<id>?api_key=<your_api_key>'
+      'https://chapi.cloudhealthtech.com/v1/price_book_assignments/<id>'
     title: Sample Request
     language: bash
 ---

--- a/_price-book/price-book-modify.md
+++ b/_price-book/price-book-modify.md
@@ -21,11 +21,11 @@ right_code_blocks:
     title: Response Body
     language: json
   - code_block: |-
-      curl --request PUT -H 'Content-Type: application/json' -d
+      curl --request PUT -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "specification": <XML>
           }'
-      'https://chapi.cloudhealthtech.com/v1/price_books/<price book id>?api_key=<your_api_key>'
+      'https://chapi.cloudhealthtech.com/v1/price_books/<price book id>'
     title: Sample Request
     language: bash
 ---

--- a/_reporting/add-dimensions-and-measures-to-report-query.md
+++ b/_reporting/add-dimensions-and-measures-to-report-query.md
@@ -8,7 +8,7 @@ parameters:
     content:
 content_markdown: |-
     1. Retrieve the list of available measures and dimensions of for the EC2 Instance Report.
-       `curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports/usage/instance/new?api_key=<your_api_key>"`
+       `curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' "https://chapi.cloudhealthtech.com/olap_reports/usage/instance/new"`
 
        This query returns a response that looks like this.
 
@@ -86,11 +86,10 @@ content_markdown: |-
        For each dimension, add a query  parameter called `dimensions[]` and for each measure add a parameter called `measures[]`. For each of these parameters, specify one or more values that you received when querying the `/new` endpoint. In general, the dimensions available are `hourly`, `daily`, `weekly`, and `monthly`.
 
        ```
-       curl -H "Accept: application/json" 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance?
+       curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance?
         dimensions[]=time
         &dimensions[]=AWS-Availaibility-Zones
         &measures[]=ec2_cost_compute
-        &interval=monthly
-        &api_key=<your_api_key>'
+        &interval=monthly'
        ```
 ---

--- a/_reporting/add-filters-to-report-query.md
+++ b/_reporting/add-filters-to-report-query.md
@@ -11,13 +11,12 @@ content_markdown: |-
 
     For example, to get the EC2 Compute Cost in `us-east-1a`, you can apply a filter in this way.
     ```
-    curl -H "Accept: application/json" 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance?
+    curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance?
       dimensions\[\]=time
       &dimensions\[\]=AWS-Availaibility-Zones
       &measures\[\]=ec2_cost_compute
       &filters\[\]=AWS-Availaibility-Zones:select:us-east-1a
-      &interval=monthly
-      &api_key=<your_api_key>
+      &interval=monthly'
     ```
 
     In the query, each filter is represented using the `filters[]` parameter. this parameter has the this structure.
@@ -27,13 +26,12 @@ content_markdown: |-
 
     For example, to get the EC2 Compute Costs for all Availability Zones except `us-east-1b` and `us-east-1d`, you can apply a filter in this way.
     ```
-    curl -H "Accept: application/json" 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance
-      ?dimensions[]=time
-      &dimensions[]=AWS-Availaibility-Zones
-      &measures[]=ec2_cost_compute
+    curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance
+      ?dimensions\[\]=time
+      &dimensions\[\]=AWS-Availaibility-Zones
+      &measures\[\]=ec2_cost_compute
       &filters\[\]=AWS-Availaibility-Zones:reject:us-east-1b,us-east-1d
-      &interval=monthly
-      &api_key=<your_api_key>'
+      &interval=monthly'
     ```
 
     For more information on how to filter by time, see [Understand Time Filters](#Reportingunderstand-time-filters).

--- a/_reporting/get-dimensions-measures.md
+++ b/_reporting/get-dimensions-measures.md
@@ -14,7 +14,7 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance/new?api_key=<your_api_key>'
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance/new'
     title: Request
     language: bash
   - code_block: |-

--- a/_reporting/get-one-custom-report.md
+++ b/_reporting/get-one-custom-report.md
@@ -29,7 +29,7 @@ content_markdown: |-
 
   2. Query the endpoint for the specific report to get its data.
 
-      `curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports/custom/<Report-ID>?api_key=<your_api_key>"`
+      `curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/custom/<Report-ID>'`
 
       This query returns a response similar to this truncated one.
 
@@ -66,7 +66,7 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports/custom/<Report-ID>?api_key=<your_api_key>"
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/custom/<Report-ID>'
     title: Request
     language: bash
   - code_block: |-

--- a/_reporting/get-one-standard-report.md
+++ b/_reporting/get-one-standard-report.md
@@ -22,7 +22,7 @@ content_markdown: |-
 
   1. Get the endpoints for all types of Standard reports.
 
-     `curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports?api_key=<your_api_key>"`
+     `curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports'`
 
      This query returns the following response.
 
@@ -47,7 +47,7 @@ content_markdown: |-
 
   2. Query the endpoint for the type of report from this response and get a list of all reports of that type. This example request queries the `/usage` endpoint to get a list of all Standard Usage Reports.
 
-     `curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports/usage?api_key=<your_api_key>"`
+     `curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/usage'`
 
      This query returns the following response, which has been truncated here for simplification.
 
@@ -69,7 +69,7 @@ content_markdown: |-
      ```
   3. Query the endpoint for the specific report to get its data. This example request queries the `/usage/instance` endpoint to get the data for the EC2 Instance Usage report.
 
-      `curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports/usage/instance?api_key=<your_api_key>"`
+      `curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance'`
 
       This query returns the following response, which has been truncated here for simplification.
 
@@ -105,7 +105,7 @@ content_markdown: |-
       {: .success}
 right_code_blocks:
   - code_block: |-
-      curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports/usage/instance?api_key=<your_api_key>"`
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/usage/instance'`
     title: Request
     language: bash
   - code_block: |-

--- a/_reporting/get-report-list.md
+++ b/_reporting/get-report-list.md
@@ -24,11 +24,11 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |
-      curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports?api_key=<your_api_key>"
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports'
     title: Basic Request
     language: bash
   - code_block: |-
-      curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports?api_key=<your_api_key>" | python -m json.tool
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' https://chapi.cloudhealthtech.com/olap_reports' | python -m json.tool
     title: Pretty print results
     language: bash
   - code_block: |-

--- a/_reporting/get-report-query.md
+++ b/_reporting/get-report-query.md
@@ -15,7 +15,7 @@ content_markdown: |-
 
 right_code_blocks:
   - code_block: |-
-      curl -v -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/custom/{report-id}?get_query=true&api_key=<your_api_key>'
+      curl -v -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/custom/{report-id}?get_query=true'
     title: Request
     language: bash
   - code_block: |-

--- a/_reporting/get-standard-reports.md
+++ b/_reporting/get-standard-reports.md
@@ -12,7 +12,7 @@ content_markdown: |-
 
   1. Get the endpoints for all types of Standard reports.
 
-     `curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports?api_key=<your_api_key>"`
+     `curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports'`
 
      This query returns the following response.
 
@@ -37,12 +37,12 @@ content_markdown: |-
 
   2. Query the endpoint for the type of report from this response and get a list of all reports of that type.
 
-     `curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports/cost?api_key=<your_api_key>"`
+     `curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/cost'`
 right_code_blocks:
   - code_block: |-
-      curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports?api_key=<your_api_key>"
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports'
 
-      curl -H "Accept: application/json" "https://chapi.cloudhealthtech.com/olap_reports/cost?api_key=<your_api_key>"`
+      curl -H 'Authorization: Bearer <your_api_key>' -H 'Accept: application/json' 'https://chapi.cloudhealthtech.com/olap_reports/cost'`
     title: Request
     language: bash
   - code_block: |-

--- a/_service-principal/service-principal-connect.md
+++ b/_service-principal/service-principal-connect.md
@@ -133,7 +133,7 @@ right_code_blocks:
     title: Response Body for Direct Customer
     language: json
   - code_block: |-
-      curl --request POST -H 'Content-Type: application/json' -d
+      curl --request POST -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "name": "Production SP",
           "sp_type": "govcloud"  ,
@@ -147,7 +147,7 @@ right_code_blocks:
             }],     
           "create_sp_for_partner_customer": <client_api_id>
         }'
-          'https://chapi.cloudhealthtech.com/v1/azure_service_principals?api_key=<your_api_key>'
+          'https://chapi.cloudhealthtech.com/v1/azure_service_principals'
     title: Sample Request
     language: bash
 ---

--- a/_service-principal/service-principal-get-all.md
+++ b/_service-principal/service-principal-get-all.md
@@ -6,8 +6,8 @@ type: get
 endpoint: https://chapi.cloudhealthtech.com/v1/azure_service_principals
 right_code_blocks:
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json' -d
-          'https://chapi.cloudhealthtech.com/v1/azure_service_principals/?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
+          'https://chapi.cloudhealthtech.com/v1/azure_service_principals/'
     title: Sample Request
     language: bash
 ---

--- a/_service-principal/service-principal-get-detail.md
+++ b/_service-principal/service-principal-get-detail.md
@@ -6,8 +6,8 @@ type: get
 endpoint: https://chapi.cloudhealthtech.com/v1/azure_service_principals/:sp_id
 right_code_blocks:
   - code_block: |-
-      curl --request GET -H 'Content-Type: application/json' -d
-          'https://chapi.cloudhealthtech.com/v1/azure_service_principals/<sp_id>/?api_key=<your_api_key>'
+      curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
+          'https://chapi.cloudhealthtech.com/v1/azure_service_principals/<sp_id>/'
     title: Sample Request
     language: bash
 ---

--- a/_service-principal/service-principal-modify.md
+++ b/_service-principal/service-principal-modify.md
@@ -69,7 +69,7 @@ right_code_blocks:
     title: Response Body for Direct Customer
     language: json
   - code_block: |-
-      curl --request PUT -H 'Content-Type: application/json' -d
+      curl --request PUT -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d
         '{
           "name": "Production SP 1",
           "client_secret": "cbdefeb",
@@ -81,7 +81,7 @@ right_code_blocks:
             "AzureKeyVaultSecret":false
           }]
         }'
-          'https://chapi.cloudhealthtech.com/v1/azure_service_principals/<sp_id>?api_key=<your_api_key>'
+          'https://chapi.cloudhealthtech.com/v1/azure_service_principals/<sp_id>'
     title: Sample Request
     language: bash
 ---

--- a/_tagging/post-tags-for-assets.md
+++ b/_tagging/post-tags-for-assets.md
@@ -15,8 +15,7 @@ content_markdown: |-
   * If there is a mix of updates and errors, the HTTP response code will still be `200 OK`.
 right_code_blocks:
   - code_block: |-
-      curl -H "Accept: application/json" -H "Content-Type: application/json" -XPOST "https://chapi.cloudhealthtech.com/v1/custom_tags?
-        api_key=<your_api_key>"
+      curl -H 'Authorization: Bearer <your_api_key>' -H "Accept: application/json" -H 'Content-Type: application/json' -XPOST 'https://chapi.cloudhealthtech.com/v1/custom_tags'
         -d '{
           "tag_groups":[
             {


### PR DESCRIPTION
Updated all examples in the doc to explain that the API key can now be
specified as an `Authorization: Bearer` header.