### PR TITLE
CloudWatch namespace specification

### DIFF
--- a/_account/aws-account-add.md
+++ b/_account/aws-account-add.md
@@ -76,7 +76,13 @@ parameters:
     sub-fields:
       - name: enabled
         required: yes
-        content: Should CloudHealth collect AWS Config files? Default value is `True`
+        content: Boolean that specified whether CloudHealth collect AWS CloudWatch data. Default value is `True`
+      - name: namespaces
+        required: no
+        content: String that specifies the namespaces from which CloudWatch data should be gathered. Value can be `CWAgent`, `System/Linux`, or `System/Windows`.
+      - name: runtime
+        required: no
+        content: Number that specifies the frequency in hours at which CloudHealth should gather CloudWatch data. Default value is `1`. Value can be `1` or `24`.
   - name: tags
     required: no
     content: JSON array that specifies key-value pairs for tags. When you use this field, The API restricts queries to AWS accounts that are tagged with these key-value pairs.

--- a/_account/aws-account-add.md
+++ b/_account/aws-account-add.md
@@ -79,7 +79,7 @@ parameters:
         content: Boolean that specified whether CloudHealth collect AWS CloudWatch data. Default value is `True`
       - name: namespaces
         required: no
-        content: String that specifies the namespaces from which CloudWatch data should be gathered. Value can be `CWAgent`, `System/Linux`, or `System/Windows`.
+        content: String that specifies the namespaces from which CloudWatch data should be gathered. Value can be `CWAgent`, `System/Linux`, `System/Windows`, or a comma-separated list of two or more of these values. Default value is an empty string.
       - name: runtime
         required: no
         content: Number that specifies the frequency in hours at which CloudHealth should gather CloudWatch data. Default value is `1`. Value can be `1` or `24`.
@@ -167,7 +167,8 @@ right_code_blocks:
           "prefix": "foo"
         },
         "cloudwatch": {
-          "enabled": true
+          "enabled": true,
+          "namespaces": "CWAgent,System/Linux,System/Windows",
         },
         "tags": [
         {

--- a/_account/aws-account-update.md
+++ b/_account/aws-account-update.md
@@ -76,7 +76,7 @@ parameters:
         content: Should CloudHealth collect AWS Config files? Default value is `True`
       - name: namespaces
         required: no
-        content: String that specifies the namespaces from which CloudWatch data should be gathered. Value can be `CWAgent`, `System/Linux`, or `System/Windows`.
+        content: String that specifies the namespaces from which CloudWatch data should be gathered. Value can be `CWAgent`, `System/Linux`, `System/Windows`, or a comma-separated list of two or more of these values. Default value is an empty string.
       - name: runtime
         required: no
         content: Number that specifies the frequency in hours at which CloudHealth should gather CloudWatch data. Default value is `1`. Value can be `1` or `24`.

--- a/_account/aws-account-update.md
+++ b/_account/aws-account-update.md
@@ -74,6 +74,12 @@ parameters:
       - name: enabled
         required: yes
         content: Should CloudHealth collect AWS Config files? Default value is `True`
+      - name: namespaces
+        required: no
+        content: String that specifies the namespaces from which CloudWatch data should be gathered. Value can be `CWAgent`, `System/Linux`, or `System/Windows`.
+      - name: runtime
+        required: no
+        content: Number that specifies the frequency in hours at which CloudHealth should gather CloudWatch data. Default value is `1`. Value can be `1` or `24`.
   - name: tags
     required: no
     content: JSON field that specifies key-value pairs for tags. When you use this field, The API restricts queries to AWS accounts that are tagged with these key-value pairs.


### PR DESCRIPTION
Added parameter values for specifying CloudWatch namespaces when adding or editing an AWS account.