### PR TITLE
Adding org_id field to all supported end points

### DIFF
--- a/_account/aws-account-add.md
+++ b/_account/aws-account-add.md
@@ -89,6 +89,9 @@ parameters:
   - name: primary_aws_region
     required: no
     content: String that specifies which region should be used to validate the read-only IAM policy. Value can be `us-east-1` (default) or `eu-central-1` for global AWS accounts. GovCloud customers cannot modify their default AWS region, `us-gov-west-1`.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   Result header contains `Location: https://chapi.cloudhealthtech.com/v1/aws_accounts/1`
 right_code_blocks:

--- a/_account/aws-account-read-multiple.md
+++ b/_account/aws-account-read-multiple.md
@@ -11,6 +11,9 @@ parameters:
     content: Specify the page number for results
   - name: per_page
     content: Specify how many results should be displayed per page. Default value is 30. Maximum value is 100.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 right_code_blocks:
   - code_block: |-
       curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' "https://chapi.cloudhealthtech.com/v1/aws_accounts"

--- a/_asset/get-asset-list.md
+++ b/_asset/get-asset-list.md
@@ -5,8 +5,9 @@ description: Retrieve the API names of all AWS, Azure, Data Center, and Google C
 position: 2
 endpoint: https://chapi.cloudhealthtech.com/api
 parameters:
-  - name:
-    content:
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   The response to this query contains a list of JSON objects that represent all the AWS, Azure, Data Center, and Google Cloud assets that CloudHealth has discovered in your environment.
 right_code_blocks:

--- a/_asset/get-specific-asset.md
+++ b/_asset/get-specific-asset.md
@@ -5,8 +5,9 @@ endpoint: https://chapi.cloudhealthtech.com/api/:asset
 position: 3
 description: Retrieve the attributes and related assets for a single asset object.
 parameters:
-  - name:
-    content:
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   The response to this query contains two arrays: `attributes` and `relations`.
 

--- a/_asset/query-asset-object.md
+++ b/_asset/query-asset-object.md
@@ -14,6 +14,9 @@ parameters:
   - name: include
     required: no
     content: String that specifies the name of a related asset object to include when returning a response. You cannot use both the `include` parameter and the `fields` parameter in the same GET query.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
   - name: api_version
     required: no
     content: Integer that specifies the API version to use. Possible values are `1` (default) and `2`. Version 1 queries only return assets are are active. Version 2 queries return both active and inactive assets.

--- a/_metrics/get-metrics-for-an-asset.md
+++ b/_metrics/get-metrics-for-an-asset.md
@@ -26,6 +26,9 @@ parameters:
   - name: per_page
     required: no
     content: Integer between `1` and `500` that specifies the number of assets to return per page. Default value is `100` and maximum value is `1000`.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   By default, the request returns hourly sets of metric points for the previous day. If there are more than 100 data value sets, a next link to the next page of value sets is also returned
 

--- a/_metrics/post-metrics-for-an-asset.md
+++ b/_metrics/post-metrics-for-an-asset.md
@@ -11,6 +11,9 @@ parameters:
   - name: dryrun
     required: no
     content: Test a POST operation without triggering a database change. Specified as `true` or `false` (default).
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   You can only post up to 8 days of historical metrics data.
   {:.warning}

--- a/_organization/get-org-id.md
+++ b/_organization/get-org-id.md
@@ -2,7 +2,7 @@
 title: How to Get Organization ID
 position: 2
 content_markdown: |-
-  In order to use some Organization endpoints, you need to provide the `org_id`. CloudHealth generates a unique ID for each organization. You can get the Organization ID for an organization from the CloudHealth Platform. From the left menu, go to **setup > admin > organizations** and view or edit the organization. The Organization ID appears in the browser URL. Here's an example URL:
+  In order to use some Organization endpoints, you need to provide the `org_id`. CloudHealth generates a unique ID for each organization. You can get the Organization ID for an organization from the CloudHealth Platform. From the left menu, go to **Setup > Admin > Organizations** and view or edit the organization. The Organization ID appears in the browser URL. Here's an example URL:
 
   ```
   https://apps.cloudhealthtech.com/organizations/20XXXXXXXX09

--- a/_organization/org-get-all-v2.md
+++ b/_organization/org-get-all-v2.md
@@ -11,6 +11,9 @@ parameters:
   - name: page
     required: no
     content: Specify the page number for results.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 right_code_blocks:
   - code_block: |-
       curl --request GET -H 'Authorization: Bearer <your_api_key>' -H 'Content-Type: application/json' -d

--- a/_perspectives/create-perspective-schema.md
+++ b/_perspectives/create-perspective-schema.md
@@ -8,6 +8,9 @@ parameters:
   - name: include_version
     required: no
     content: Boolean that defines whether the current version of the perspective is returned in the response.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   #### How to Duplicate a Perspective
   To duplicate a Perspective, retrieve the schema from the source Perspective (e.g., Perspective A) and POST that schema with a new name (e.g., Perspective B) to create a duplicate of Perspective A. All references in the schema rules to existing groups and blocks in Perspective A are seen as directives to create corresponding groups in Perspective B. Perspective A and its Groups remain unchanged.

--- a/_perspectives/delete-perspective-schema.md
+++ b/_perspectives/delete-perspective-schema.md
@@ -11,6 +11,9 @@ parameters:
   - name: hard_delete
     required: no
     content: Boolean that specifies whether the Hard Delete option is exercised. See [Hard Delete](#hard-delete).
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   There are three levels of Perspective deletion.
   #### Soft Delete (default)

--- a/_perspectives/get-all-perspectives.md
+++ b/_perspectives/get-all-perspectives.md
@@ -10,6 +10,9 @@ parameters:
   - name: active_only
     required: no
     content: Boolean that specifies whether only active Perspectives are returned in the response.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 right_code_blocks:
   - code_block: |-
       curl -s -H "Accept: application/json" "https://chapi.cloudhealthtech.com/v1/perspective_schemas?api_key=<api key>"

--- a/_perspectives/get-perspective-schema.md
+++ b/_perspectives/get-perspective-schema.md
@@ -8,6 +8,9 @@ parameters:
   - name: include_version
     required: no
     content: Boolean that defines whether the current version of the perspective is returned in the response.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 right_code_blocks:
   - code_block: |-
       curl -s -H "Accept: application/json" "https://chapi.cloudhealthtech.com/v1/perspective_schemas/<perspective_id>?api_key=<api_key>"

--- a/_perspectives/update-perspective-schema.md
+++ b/_perspectives/update-perspective-schema.md
@@ -11,7 +11,9 @@ parameters:
   - name: include_version
     required: no
     content: Boolean that defines whether the current version of the perspective is returned in the response.
-
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   If the schema contains references to Groups that do no exist in the Perspective, the PUT operation creates those Groups in the Perspective.
   {:.warning}

--- a/_reporting/get-dimensions-measures.md
+++ b/_reporting/get-dimensions-measures.md
@@ -5,8 +5,9 @@ description: Get dimensions and measures for a report so that you can build gran
 position: 7
 endpoint: https://chapi.cloudhealthtech.com/olap_reports/:report-type/:report-id/new
 parameters:
-  - name:
-    content:
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   You can build granular report queries by passing dimensions and measures into the query string. In order to build detailed queries, first discover which dimensions and measures are available at the endpoint for each report.
 

--- a/_reporting/get-one-custom-report.md
+++ b/_reporting/get-one-custom-report.md
@@ -17,6 +17,9 @@ parameters:
   - name: filters
     required: no
     content: Array that specifies the filters to use for constraining report data.
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   Custom reports are saved versions of Standard Reports. Retrieving the data for a specific saved report involves the following steps.
 

--- a/_reporting/get-report-list.md
+++ b/_reporting/get-report-list.md
@@ -5,8 +5,9 @@ description: Retrieve a list of Standard OLAP reports that you can query.
 position: 3
 endpoint: https://chapi.cloudhealthtech.com/olap_reports
 parameters:
-  - name:
-    content:
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   The response to this query contains a list of endpoints that provide Standard CloudHealth reports of specific types. The following endpoints are returned.
   * `/cost`

--- a/_reporting/get-report-query.md
+++ b/_reporting/get-report-query.md
@@ -4,8 +4,9 @@ type: example
 description: Retrieve the query string and parameters that produce a Standard or Custom OLAP report.
 position: 8
 parameters:
-  - name:
-    content:
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   Each CloudHealth report is produced by a combination of parameters that together compose a query string.
   You can retrieve the query string that produces a Standard or Custom report.

--- a/_reporting/get-standard-reports.md
+++ b/_reporting/get-standard-reports.md
@@ -5,8 +5,9 @@ description: Retrieve the list of available Standard OLAP reports of a specify t
 position: 4
 endpoint: https://chapi.cloudhealthtech.com/olap_reports/:report-type
 parameters:
-  - name:
-    content:
+  - name: org_id
+    required: no
+    content: String that specifies the ID of the organization in which this query should run. See [How to Get Organization ID](#organization_how-to-get-organization-id). If not specified, this parameter assumes the ID of your default organization.
 content_markdown: |-
   Retrieving a list of all reports of a specific type, such as `/cost`, `/custom`, `/performance`, or `/usage` is a two-step process.
 


### PR DESCRIPTION
We have introduced an optional argument called ‘org_id’ to specify which Organization ID you would like to run against. This is supported in the following APIs:
* Asset API
* Reporting API
* Perspective API
* Metrics API
* Organizations API
* AWS Account Configuration API