### PR TITLE
Added billing_family_owner_id to response

### DIFF
--- a/_assignment/aws-account-assignment-create-v2.md
+++ b/_assignment/aws-account-assignment-create-v2.md
@@ -68,6 +68,7 @@ right_code_blocks:
             "owner_id": "000000000001",
             "target_client_api_id": 123,
             "payer_account_owner_id": "000000000001",
+            "billing_family_owner_id": "000000000005",
             "billing_block_type": "Family",
             "billing_block_name": "block name1",
             "errors": {}
@@ -77,6 +78,7 @@ right_code_blocks:
             "owner_id": "000000000002",
             "target_client_api_id": 1234,
             "payer_account_owner_id": "000000000002",
+            "billing_family_owner_id": "000000000006",
             "billing_block_type": "Consolidated",
             "billing_block_name": "block name2",
             "errors": {}
@@ -86,6 +88,7 @@ right_code_blocks:
             "owner_id": "000000000003",
             "target_client_api_id": 1234,
             "payer_account_owner_id": "000000000002",
+            "billing_family_owner_id": "000000000007",
             "billing_block_type": "Consolidated",
             "billing_block_name": "block name2",
             "errors": {}
@@ -95,6 +98,7 @@ right_code_blocks:
             "owner_id": "000000000004",
             "target_client_api_id": 1234,
             "payer_account_owner_id": "000000000004",
+            "billing_family_owner_id": "000000000008",
             "billing_block_type": "Standalone",
             "billing_block_name": "block name3",
             "errors": {}

--- a/_assignment/aws-account-assignment-create-v2.md
+++ b/_assignment/aws-account-assignment-create-v2.md
@@ -68,7 +68,7 @@ right_code_blocks:
             "owner_id": "000000000001",
             "target_client_api_id": 123,
             "payer_account_owner_id": "000000000001",
-            "billing_family_owner_id": "000000000005",
+            "billing_family_owner_id": "000000000001",
             "billing_block_type": "Family",
             "billing_block_name": "block name1",
             "errors": {}

--- a/_assignment/aws-account-assignment-create-v2.md
+++ b/_assignment/aws-account-assignment-create-v2.md
@@ -88,7 +88,7 @@ right_code_blocks:
             "owner_id": "000000000003",
             "target_client_api_id": 1234,
             "payer_account_owner_id": "000000000002",
-            "billing_family_owner_id": "000000000007",
+            "billing_family_owner_id": "000000000006",
             "billing_block_type": "Consolidated",
             "billing_block_name": "block name2",
             "errors": {}
@@ -98,7 +98,7 @@ right_code_blocks:
             "owner_id": "000000000004",
             "target_client_api_id": 1234,
             "payer_account_owner_id": "000000000004",
-            "billing_family_owner_id": "000000000008",
+            "billing_family_owner_id": "000000000007",
             "billing_block_type": "Standalone",
             "billing_block_name": "block name3",
             "errors": {}

--- a/_assignment/aws-account-assignment-read-single-v2.md
+++ b/_assignment/aws-account-assignment-read-single-v2.md
@@ -11,6 +11,7 @@ content_markdown: |-
   * `owner_id`: The AWS ID of the assigned account
   * `target_client_api_id`: The client API ID of the customer
   * `payer_account_owner_id`: The AWS ID of the account whose bills receive the billing line items for the assigned account
+  * `billing_family_owner_id`: The AWS ID of the billing family of the assigned account
   * `billing_block_type`: The type of billing block
   * `billing_block_name`: The name of the billing block
 

--- a/_assignment/aws-account-assignment-read-v2.md
+++ b/_assignment/aws-account-assignment-read-v2.md
@@ -17,6 +17,7 @@ content_markdown: |-
   * `id`: The ID of an AWS account assignment
   * `owner_id`: The AWS ID of the assigned account
   * `payer_account_owner_id`: The AWS ID of the account whose bills receive the billing line items for the assigned account
+  * `billing_family_owner_id`: The AWS ID of the billing family of the assigned account
   * `billing_block_type`: The type of billing block
   * `billing_block_name`: The name of the billing block
 

--- a/_assignment/aws-account-assignment-update-v2.md
+++ b/_assignment/aws-account-assignment-update-v2.md
@@ -33,6 +33,7 @@ right_code_blocks:
             "owner_id": "000000000002",
             "target_client_api_id": 1234,
             "payer_account_owner_id": "000000000003",
+            "billing_family_owner_id": "000000000001",
             "billing_block_type": "Consolidated",
             "billing_block_name": "block name2",
             "errors": {}
@@ -42,6 +43,7 @@ right_code_blocks:
             "owner_id": "000000000003",
             "target_client_api_id": 1234,
             "payer_account_owner_id": "000000000003",
+            "billing_family_owner_id": "000000000001",
             "billing_block_type": "Consolidated",
             "billing_block_name": "block name2",
             "errors": {}


### PR DESCRIPTION
Updated AWS account assignment documentation to reflect the addition of billing_family_owner_id to the response